### PR TITLE
Made the error output on which "softer"

### DIFF
--- a/lib/jpegtran-bin.js
+++ b/lib/jpegtran-bin.js
@@ -3,6 +3,7 @@
 var path = require('path');
 var url = require('url');
 var which = require('which');
+var colors = require('colors');
 
 var target = {
 	name: 'jpegtran',
@@ -89,7 +90,7 @@ function setPath(target) {
 		return which.sync(target.name);
 	}
 	catch(e) {
-		console.log(e);
+		console.warn('could not find existing '.yellow + target.name);
 		return getPathToPackagedBinary(target);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jpegtran-bin",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "jpegtran (part of libjpeg-turbo) wrapper that makes it seamlessly available as a local dependency on OS X, Linux and Windows. Most commonly used to losslessly minify JPEG images.",
   "keywords": [
     "jpeg",


### PR DESCRIPTION
Error sounds bad, it was being thrown by the `which` module.  Made it display in yellow and more human readable.

Also throwing in a version bump for npm update.
