### PR TITLE
added proxy option

### DIFF
--- a/pre-build.js
+++ b/pre-build.js
@@ -10,6 +10,11 @@ var build = require('./build');
 var jpegtran = require('./lib/jpegtran');
 var binPath = jpegtran.path;
 
+var proxyServer = process.env.HTTPS_PROXY
+	|| process.env.https_proxy
+	|| process.env.HTTP_PROXY
+	|| process.env.http_proxy;
+
 function runTest() {
 	mocha.addFile('test/test-path.js');
 	mocha.run(function (failures) {
@@ -28,6 +33,10 @@ if (fs.existsSync(binPath)) {
 	if (!fs.existsSync(path.dirname(binPath))) {
 		mkdir.sync(path.dirname(binPath));
 	}
+
+	if (proxyServer) {
+    	request = request.defaults({ proxy: proxyServer, timeout: 5000 });
+  	}
 
 	return request.get(jpegtran.url)
 		.pipe(fs.createWriteStream(binPath))


### PR DESCRIPTION
`pre-build.js` tries to download the required files from the server but if
you are behind a corporate proxy server it will fail. By using the
environment variables to check for a proxy setting this could be avoided
and all those sad little men behind a proxy will be happy.
