### PR TITLE
Fixes #37 - installation on windows

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -16,7 +16,7 @@ bin.check(args, function (w) {
 		console.log(chalk.red('✗ pre-build test failed, compiling from source...'));
 
 		if (process.platform === 'win32') {
-			throw new Error('building is not supported on ' + process.platform);
+			return console.log(chalk.yellow('? building is not supported on ' + process.platform));
 		}
 
 		return bin.build(function (err) {


### PR DESCRIPTION
Instead of throwing an error, just return a warning to prevent npm install from exiting out when installing the package on Windows systems.
