### PR TITLE
Broken Compile

### DIFF
--- a/lib/jpegtran.js
+++ b/lib/jpegtran.js
@@ -8,7 +8,7 @@ var options = {
 	bin: 'jpegtran',
 	path: path.join(__dirname, '../vendor'),
 	src: 'http://downloads.sourceforge.net/project/libjpeg-turbo/1.3.0/libjpeg-turbo-1.3.0.tar.gz',
-	buildScript: './configure --disable-shared --prefix="' + path + '" && ' + 'make install',
+	buildScript: './configure --disable-shared --prefix="' + path.join(__dirname, '../vendor') + '" && ' + 'make install',
 	platform: {
 		darwin: {
 			url: 'https://raw.github.com/yeoman/node-jpegtran-bin/master/vendor/osx/jpegtran'


### PR DESCRIPTION
`path` in the `options.buildScript` references `var path ...` at the top of the script, not `options.path` in-lined path call and it works.

Not sure if there is a better solution....
