### PR TITLE
inline path, variable reference confusion with `var path`  declared outside of options object.

### DIFF
--- a/lib/jpegtran.js
+++ b/lib/jpegtran.js
@@ -8,7 +8,7 @@ var options = {
 	bin: 'jpegtran',
 	path: path.join(__dirname, '../vendor'),
 	src: 'http://downloads.sourceforge.net/project/libjpeg-turbo/1.3.0/libjpeg-turbo-1.3.0.tar.gz',
-	buildScript: './configure --disable-shared --prefix="' + path + '" && ' + 'make install',
+	buildScript: './configure --disable-shared --prefix="' + path.join(__dirname, '../vendor') + '" && ' + 'make install',
 	platform: {
 		darwin: {
 			url: 'https://raw.github.com/yeoman/node-jpegtran-bin/master/vendor/osx/jpegtran'


### PR DESCRIPTION
Couldn't squash commits on https://github.com/yeoman/node-jpegtran-bin/pull/39, new clean branch with the fix.
