### PR TITLE
Add configure flags to for 32-bit build on 64-bit Mac OS X machine

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -21,9 +21,13 @@ bin.run(args, function (err) {
 	if (err) {
 		console.log(logSymbols.warning + ' pre-build test failed, compiling from source...');
 
+		var flags = '';
+		if (process.platform === 'darwin' && process.arch === 'x64') {
+			flags = 'CFLAGS="-m32" LDFLAGS="-m32" ';
+		}
 		var builder = new BinBuild()
 			.src('http://downloads.sourceforge.net/project/libjpeg-turbo/' + bin.v + '/libjpeg-turbo-' + bin.v + '.tar.gz')
-			.cmd('./configure --disable-shared --prefix="' + bin.dest() + '" --bindir="' + bin.dest() + '"')
+			.cmd(flags + './configure --disable-shared --prefix="' + bin.dest() + '" --bindir="' + bin.dest() + '"')
 			.cmd('make install');
 
 		return builder.build(function (err) {


### PR DESCRIPTION
I tried and found that configure fails on 64-bit Mac OS X machine with no configure flags.
Following https://github.com/Aries85/LightZone/commit/4e376e, I added "-m32" to CFLAGS and LDFLAGS and it builds successfully.

Could you review this pull request and merge it?
Thanks!
