### PR TITLE
Exit with error code if compilation fails.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -40,6 +40,7 @@ bin.run(args, function (err) {
 		return builder.run(function (err) {
 			if (err) {
 				log.error(err.stack);
+				process.exit(1);
 				return;
 			}
 


### PR DESCRIPTION
If we are unable to download or compile the underlying jpegtran binary, the build script should be terminated with a non-zero exit code.

This error should cascade upwards, so that npm (and any dependant packages) are aware of the failure.

Thanks to Github's recent network issues, builds in our CI environment (mysteriously) started to fail today, because this package's requests to download the precompiled binaries from Github were failing and unsuccessfully trying to fall back to a manual build (because `nasm` [isn't installed](https://github.com/imagemin/jpegtran-bin/issues/9) in our CI environment).