### PR TITLE
Change version tag to include v

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 var path = require('path');
 var BinWrapper = require('bin-wrapper');
 var pkg = require('../package.json');
-var url = 'https://raw.github.com/imagemin/jpegtran-bin/' + pkg.version + '/vendor/';
+var url = 'https://raw.github.com/imagemin/jpegtran-bin/v' + pkg.version + '/vendor/';
 
 module.exports = new BinWrapper()
 	.src(url + 'osx/jpegtran', 'darwin')


### PR DESCRIPTION
As discussed in imagemin/gifsicle-bin#55, some imagemin bin packages prepend their version
tags with v and some don't. This PR changes the behavior of this package to prepend tags 
with`v`, as do the majority of packages. This reduces the probability that a wrong tag 
is published by mistake.

Merging this PR means that the next tag must be prepended with a v!