### PR TITLE
#93 - Allow user to specify binary mirror

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,17 @@ const path = require('path');
 const BinWrapper = require('bin-wrapper');
 const pkg = require('../package.json');
 
-const url = `https://raw.githubusercontent.com/imagemin/jpegtran-bin/v${pkg.version}/vendor/`;
+
+//The default location that missing binaries are fetched from
+const defaultDownloadUrl = `https://raw.githubusercontent.com/imagemin/jpegtran-bin/`;
+const defaultDownloadDir = 'vendor/';
+
+//If we detect that a different download location has been set in the environment shall use it over the default
+const downloadUrl = process.env.IMAGEMIN__JPEGTRAN_BIN__MIRROR_URL ? process.env.IMAGEMIN__JPEGTRAN_BIN__MIRROR_URL : defaultDownloadUrl;
+const downloadDir = process.env.IMAGEMIN__JPEGTRAN_BIN__CUSTOM_DIR ? process.env.IMAGEMIN__JPEGTRAN_BIN__CUSTOM_DIR : defaultDownloadDir;
+
+const url = `${downloadUrl}v${pkg.version}/${downloadDir}`;
+
 
 module.exports = new BinWrapper()
 	.src(`${url}macos/jpegtran`, 'darwin')

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,17 +3,15 @@ const path = require('path');
 const BinWrapper = require('bin-wrapper');
 const pkg = require('../package.json');
 
-
-//The default location that missing binaries are fetched from
-const defaultDownloadUrl = `https://raw.githubusercontent.com/imagemin/jpegtran-bin/`;
+// The default location that missing binaries are fetched from
+const defaultDownloadUrl = 'https://raw.githubusercontent.com/imagemin/jpegtran-bin/';
 const defaultDownloadDir = 'vendor/';
 
-//If we detect that a different download location has been set in the environment shall use it over the default
+// If we detect that a different download location has been set in the environment shall use it over the default
 const downloadUrl = process.env.IMAGEMIN__JPEGTRAN_BIN__MIRROR_URL ? process.env.IMAGEMIN__JPEGTRAN_BIN__MIRROR_URL : defaultDownloadUrl;
 const downloadDir = process.env.IMAGEMIN__JPEGTRAN_BIN__CUSTOM_DIR ? process.env.IMAGEMIN__JPEGTRAN_BIN__CUSTOM_DIR : defaultDownloadDir;
 
 const url = `${downloadUrl}v${pkg.version}/${downloadDir}`;
-
 
 module.exports = new BinWrapper()
 	.src(`${url}macos/jpegtran`, 'darwin')

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,31 @@ You probably want [`imagemin-jpegtran`](https://github.com/imagemin/imagemin-jpe
 $ npm install --save jpegtran-bin
 ```
 
+### Customizing the Download Mirror
+
+By default this package will fetch the libjpeg-turbo binary from this repository during install, if you need to customise this behavour it can be overridden using enviroment variables.
+
+The following options are available:
+
+Environment Variable               | Description                          | Default
+-----------------------------------| -------------------------------------| --------------------------------------------------------
+IMAGEMIN__JPEGTRAN_BIN__MIRROR_URL | Specifies the location of the mirror | https://raw.githubusercontent.com/imagemin/jpegtran-bin/
+IMAGEMIN__JPEGTRAN_BIN__CUSTOM_DIR | Specifies a custom folder if needed  | vendor/
+
+The resulting mirror location is composed as follows:
+
+```js
+url = IMAGEMIN__JPEGTRAN_BIN__MIRROR_URL + {library version} + IMAGEMIN__JPEGTRAN_BIN__CUSTOM_DIR + {platform information}
+```
+
+For instance with the below set:
+
+```
+IMAGEMIN__JPEGTRAN_BIN__MIRROR_URL = 'https://www.example.com/private/mirror/'
+IMAGEMIN__JPEGTRAN_BIN__CUSTOM_DIR = 'binaries/'
+```
+
+Would result in `https://www.example.com/private/mirror/v4.0.0/binaries/win/x64/jpegtran.exe` on 64 bit Windows.
 
 ## Usage
 


### PR DESCRIPTION
Allowing configuration of the download URL of the binary files via enviroment variables for users that are not able to download the binary files from github. 