### PR TITLE
Add vendor/source to published npm files

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "index.js",
     "cli.js",
     "lib",
-    "test"
+    "test",
+    "vendor/source"
   ],
   "keywords": [
     "imagemin",


### PR DESCRIPTION
When attempting to install version 5.0.1 on a client that builds from source (e.g., alpine), the install fails with: `✖ Error: ENOENT: no such file or directory, open '/node_modules/jpegtran-bin/vendor/source/libjpeg-turbo-1.5.1.tar.gz'`.

This is due to the tar file not being published to npm; therefore, it is not available to be used for the compile step.

This change simply adds the `vendor/source` directory to the files that will be published to npm.